### PR TITLE
Replace dead mapbox basemap tilelayer with CartoDB Darkmatter

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,13 +29,9 @@
     function initMap() {
         var map = L.map('map').setView([51.505, -0.09], 13);
 
-        L.tileLayer('https://{s}.tiles.mapbox.com/v3/{id}/{z}/{x}/{y}.png', {
-	    maxZoom: 18,
-	    attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
-                         '<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
-			 'Imagery © <a href="http://mapbox.com">Mapbox</a>',
-    	    id: 'examples.map-i875mjb7'
-        }).addTo(map);
+        L.tileLayer('http://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png',{
+  attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
+        }).addTo(map)
 
         L.Control.boxzoom({ position:'topleft' }).addTo(map);
     }


### PR DESCRIPTION
The basemap in your example was not loading, this is a free basemap hosted by CartoDB.  Sweet plugin.  